### PR TITLE
Remove changing of m_szFriends on TalkInit

### DIFF
--- a/dlls/scientist.cpp
+++ b/dlls/scientist.cpp
@@ -695,12 +695,6 @@ void CScientist::TalkInit()
 {
 	CTalkMonster::TalkInit();
 
-	// scientist will try to talk to friends in this order:
-
-	m_szFriends[0] = "monster_scientist";
-	m_szFriends[1] = "monster_sitting_scientist";
-	m_szFriends[2] = "monster_barney";
-
 	// scientists speach group names (group names are in sentences.txt)
 
 	m_szGrp[TLK_ANSWER] = "SC_ANSWER";


### PR DESCRIPTION
Talkorder depends on FriendNumber member function and it's already reimplemented for monster_scientist.