### PR TITLE
Fix goldsource fullscreen when resolution is different from screen's one

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -212,7 +212,9 @@ void TeamFortressViewport::paintBackground()
 //	int wide, tall;
 //	getParent()->getSize( wide, tall );
 //	setSize( wide, tall );
-	gEngfuncs.VGui_ViewportPaintBackground(HUD_GetRect());
+	int extents[4];
+	getParent()->getAbsExtents(extents[0],extents[1],extents[2],extents[3]);
+	gEngfuncs.VGui_ViewportPaintBackground(extents);
 }
 
 void *TeamFortressViewport::operator new( size_t stAllocateBlock )


### PR DESCRIPTION
How to replicate a bug: make the goldsource fullscreen and change resolution to any that's lower than screen resolution. This is how it looks:

![screenshot from 2018-11-27 08-52-09](https://user-images.githubusercontent.com/5596503/49061554-074b8600-f222-11e8-899b-bc61ffcbf0fd.png)

This patch fixes the issue.