### PR TITLE
Fix hornetgun recharge time on changelevel

### DIFF
--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -1617,7 +1617,7 @@ IMPLEMENT_SAVERESTORE( CEgon, CBasePlayerWeapon )
 
 TYPEDESCRIPTION CHgun::m_SaveData[] =
 {
-	DEFINE_FIELD( CHgun, m_flRechargeTime, FIELD_FLOAT ),
+	DEFINE_FIELD( CHgun, m_flRechargeTime, FIELD_TIME ),
 };
 
 IMPLEMENT_SAVERESTORE( CHgun, CBasePlayerWeapon )


### PR DESCRIPTION
Note that valve sdk does not have hornetgun recharge time in save/restore at all. Because of this original behavior for hornetgun is to reset its ammo to maximum upon changelevel.

Recharge time was added to save/restore in https://github.com/FWGS/hlsdk-xash3d/commit/740a5a2c31b799dd3f8bd4e5312451489e3cafbe#diff-0fea681efb1fd613feb6d48bb36e21d2
This commit just fixes wrong variable type.

Depending on our policies regarding preserving original save/restore or not we might remove the change made at the first place.