### PR TITLE
Use line height from screen info in motd and scoreboard

### DIFF
--- a/cl_dll/MOTD.cpp
+++ b/cl_dll/MOTD.cpp
@@ -56,7 +56,7 @@ void CHudMOTD::Reset( void )
 	m_bShow = 0;
 }
 
-#define LINE_HEIGHT  13
+#define LINE_HEIGHT  (gHUD.m_scrinfo.iCharHeight)
 #define ROW_GAP  13
 #define ROW_RANGE_MIN 30
 #define ROW_RANGE_MAX ( ScreenHeight - 100 )

--- a/cl_dll/scoreboard.cpp
+++ b/cl_dll/scoreboard.cpp
@@ -108,7 +108,7 @@ We have a minimum width of 1-320 - we could have the field widths scale with it?
 int SCOREBOARD_WIDTH = 320;
 
 // Y positions
-#define ROW_GAP  13
+#define ROW_GAP  (gHUD.m_scrinfo.iCharHeight)
 #define ROW_RANGE_MIN 15
 #define ROW_RANGE_MAX ( ScreenHeight - 50 )
 


### PR DESCRIPTION
Text does look right for me, at least on Linux, probably because of different font sizes on different platforms. Better use gHUD.m_scrinfo.iCharHeight for y-pos calculations.

Before:
![crossfire0000](https://user-images.githubusercontent.com/5596503/55950440-9ef3c300-5c5d-11e9-92e0-ca0cecb52695.png)
![crossfire0001](https://user-images.githubusercontent.com/5596503/55950443-9ef3c300-5c5d-11e9-8f23-ab8912c375c4.png)

After:
![crossfire0003](https://user-images.githubusercontent.com/5596503/55950446-9ef3c300-5c5d-11e9-96a0-3c371165f5e4.png)
![crossfire0002](https://user-images.githubusercontent.com/5596503/55950444-9ef3c300-5c5d-11e9-914b-141113f34878.png)




