### PR TITLE
Add spaces between source files in compile.bat

### DIFF
--- a/cl_dll/compile.bat
+++ b/cl_dll/compile.bat
@@ -8,68 +8,68 @@ echo -- Compiler is MSVC6
 
 set XASH3DSRC=..\..\Xash3D_original
 set INCLUDES=-I../common -I../engine -I../pm_shared -I../game_shared -I../public -I../external -I../dlls -I../utils/false_vgui/include
-set SOURCES=../dlls/crossbow.cpp^
-	../dlls/crowbar.cpp^
-	../dlls/egon.cpp^
-	../dlls/gauss.cpp^
-	../dlls/handgrenade.cpp^
-	../dlls/hornetgun.cpp^
-	../dlls/mp5.cpp^
-	../dlls/python.cpp^
-	../dlls/rpg.cpp^
-	../dlls/satchel.cpp^
-	../dlls/shotgun.cpp^
-	../dlls/squeakgrenade.cpp^
-	../dlls/tripmine.cpp^
-	../dlls/glock.cpp^
-	ev_hldm.cpp^
-	hl/hl_baseentity.cpp^
-	hl/hl_events.cpp^
-	hl/hl_objects.cpp^
-	hl/hl_weapons.cpp^
-	ammo.cpp^
-	ammo_secondary.cpp^
-	ammohistory.cpp^
-	battery.cpp^
-	cdll_int.cpp^
-	com_weapons.cpp^
-	death.cpp^
-	demo.cpp^
-	entity.cpp^
-	ev_common.cpp^
-	events.cpp^
-	flashlight.cpp^
-	GameStudioModelRenderer.cpp^
-	geiger.cpp^
-	health.cpp^
-	hud.cpp^
-	hud_msg.cpp^
-	hud_redraw.cpp^
-	hud_spectator.cpp^
-	hud_update.cpp^
-	in_camera.cpp^
-	input.cpp^
-	input_goldsource.cpp^
-	input_mouse.cpp^
-	input_xash3d.cpp^
-	menu.cpp^
-	message.cpp^
-	overview.cpp^
-	parsemsg.cpp^
-	../pm_shared/pm_debug.c^
-	../pm_shared/pm_math.c^
-	../pm_shared/pm_shared.c^
-	saytext.cpp^
-	status_icons.cpp^
-	statusbar.cpp^
-	studio_util.cpp^
-	StudioModelRenderer.cpp^
-	text_message.cpp^
-	train.cpp^
-	tri.cpp^
-	util.cpp^
-	view.cpp^
-	scoreboard.cpp^
+set SOURCES=../dlls/crossbow.cpp ^
+	../dlls/crowbar.cpp ^
+	../dlls/egon.cpp ^
+	../dlls/gauss.cpp ^
+	../dlls/handgrenade.cpp ^
+	../dlls/hornetgun.cpp ^
+	../dlls/mp5.cpp ^
+	../dlls/python.cpp ^
+	../dlls/rpg.cpp ^
+	../dlls/satchel.cpp ^
+	../dlls/shotgun.cpp ^
+	../dlls/squeakgrenade.cpp ^
+	../dlls/tripmine.cpp ^
+	../dlls/glock.cpp ^
+	ev_hldm.cpp ^
+	hl/hl_baseentity.cpp ^
+	hl/hl_events.cpp ^
+	hl/hl_objects.cpp ^
+	hl/hl_weapons.cpp ^
+	ammo.cpp ^
+	ammo_secondary.cpp ^
+	ammohistory.cpp ^
+	battery.cpp ^
+	cdll_int.cpp ^
+	com_weapons.cpp ^
+	death.cpp ^
+	demo.cpp ^
+	entity.cpp ^
+	ev_common.cpp ^
+	events.cpp ^
+	flashlight.cpp ^
+	GameStudioModelRenderer.cpp ^
+	geiger.cpp ^
+	health.cpp ^
+	hud.cpp ^
+	hud_msg.cpp ^
+	hud_redraw.cpp ^
+	hud_spectator.cpp ^
+	hud_update.cpp ^
+	in_camera.cpp ^
+	input.cpp ^
+	input_goldsource.cpp ^
+	input_mouse.cpp ^
+	input_xash3d.cpp ^
+	menu.cpp ^
+	message.cpp ^
+	overview.cpp ^
+	parsemsg.cpp ^
+	../pm_shared/pm_debug.c ^
+	../pm_shared/pm_math.c ^
+	../pm_shared/pm_shared.c ^
+	saytext.cpp ^
+	status_icons.cpp ^
+	statusbar.cpp ^
+	studio_util.cpp ^
+	StudioModelRenderer.cpp ^
+	text_message.cpp ^
+	train.cpp ^
+	tri.cpp ^
+	util.cpp ^
+	view.cpp ^
+	scoreboard.cpp ^
 	MOTD.cpp
 set DEFINES=/DCLIENT_DLL /DCLIENT_WEAPONS /Dsnprintf=_snprintf /DNO_VOICEGAMEMGR /DGOLDSOURCE_SUPPORT
 set LIBS=user32.lib Winmm.lib

--- a/dlls/compile.bat
+++ b/dlls/compile.bat
@@ -8,105 +8,105 @@ echo -- Compiler is MSVC6
 
 set XASH3DSRC=..\..\Xash3D_original
 set INCLUDES=-I../common -I../engine -I../pm_shared -I../game_shared -I../public
-set SOURCES=agrunt.cpp^
-	airtank.cpp^
-	aflock.cpp^
-	animating.cpp^
-	animation.cpp^
-	apache.cpp^
-	barnacle.cpp^
-	barney.cpp^
-	bigmomma.cpp^
-	bloater.cpp^
-	bmodels.cpp^
-	bullsquid.cpp^
-	buttons.cpp^
-	cbase.cpp^
-	client.cpp^
-	combat.cpp^
-	controller.cpp^
-	crossbow.cpp^
-	crowbar.cpp^
-	defaultai.cpp^
-	doors.cpp^
-	effects.cpp^
-	egon.cpp^
-	explode.cpp^
-	flyingmonster.cpp^
-	func_break.cpp^
-	func_tank.cpp^
-	game.cpp^
-	gamerules.cpp^
-	gargantua.cpp^
-	gauss.cpp^
-	genericmonster.cpp^
-	ggrenade.cpp^
-	globals.cpp^
-	glock.cpp^
-	gman.cpp^
-	h_ai.cpp^
-	h_battery.cpp^
-	h_cine.cpp^
-	h_cycler.cpp^
-	h_export.cpp^
-	handgrenade.cpp^
-	hassassin.cpp^
-	headcrab.cpp^
-	healthkit.cpp^
-	hgrunt.cpp^
-	hornet.cpp^
-	hornetgun.cpp^
-	houndeye.cpp^
-	ichthyosaur.cpp^
-	islave.cpp^
-	items.cpp^
-	leech.cpp^
-	lights.cpp^
-	maprules.cpp^
-	monstermaker.cpp^
-	monsters.cpp^
-	monsterstate.cpp^
-	mortar.cpp^
-	mp5.cpp^
-	multiplay_gamerules.cpp^
-	nihilanth.cpp^
-	nodes.cpp^
-	observer.cpp^
-	osprey.cpp^
-	pathcorner.cpp^
-	plane.cpp^
-	plats.cpp^
-	player.cpp^
-	playermonster.cpp^
-	python.cpp^
-	rat.cpp^
-	roach.cpp^
-	rpg.cpp^
-	satchel.cpp^
-	schedule.cpp^
-	scientist.cpp^
-	scripted.cpp^
-	shotgun.cpp^
-	singleplay_gamerules.cpp^
-	skill.cpp^
-	sound.cpp^
-	soundent.cpp^
-	spectator.cpp^
-	squadmonster.cpp^
-	squeakgrenade.cpp^
-	subs.cpp^
-	talkmonster.cpp^
-	teamplay_gamerules.cpp^
-	tempmonster.cpp^
-	tentacle.cpp^
-	triggers.cpp^
-	tripmine.cpp^
-	turret.cpp^
-	util.cpp^
-	weapons.cpp^
-	world.cpp^
-	xen.cpp^
-	zombie.cpp^
+set SOURCES=agrunt.cpp ^
+	airtank.cpp ^
+	aflock.cpp ^
+	animating.cpp ^
+	animation.cpp ^
+	apache.cpp ^
+	barnacle.cpp ^
+	barney.cpp ^
+	bigmomma.cpp ^
+	bloater.cpp ^
+	bmodels.cpp ^
+	bullsquid.cpp ^
+	buttons.cpp ^
+	cbase.cpp ^
+	client.cpp ^
+	combat.cpp ^
+	controller.cpp ^
+	crossbow.cpp ^
+	crowbar.cpp ^
+	defaultai.cpp ^
+	doors.cpp ^
+	effects.cpp ^
+	egon.cpp ^
+	explode.cpp ^
+	flyingmonster.cpp ^
+	func_break.cpp ^
+	func_tank.cpp ^
+	game.cpp ^
+	gamerules.cpp ^
+	gargantua.cpp ^
+	gauss.cpp ^
+	genericmonster.cpp ^
+	ggrenade.cpp ^
+	globals.cpp ^
+	glock.cpp ^
+	gman.cpp ^
+	h_ai.cpp ^
+	h_battery.cpp ^
+	h_cine.cpp ^
+	h_cycler.cpp ^
+	h_export.cpp ^
+	handgrenade.cpp ^
+	hassassin.cpp ^
+	headcrab.cpp ^
+	healthkit.cpp ^
+	hgrunt.cpp ^
+	hornet.cpp ^
+	hornetgun.cpp ^
+	houndeye.cpp ^
+	ichthyosaur.cpp ^
+	islave.cpp ^
+	items.cpp ^
+	leech.cpp ^
+	lights.cpp ^
+	maprules.cpp ^
+	monstermaker.cpp ^
+	monsters.cpp ^
+	monsterstate.cpp ^
+	mortar.cpp ^
+	mp5.cpp ^
+	multiplay_gamerules.cpp ^
+	nihilanth.cpp ^
+	nodes.cpp ^
+	observer.cpp ^
+	osprey.cpp ^
+	pathcorner.cpp ^
+	plane.cpp ^
+	plats.cpp ^
+	player.cpp ^
+	playermonster.cpp ^
+	python.cpp ^
+	rat.cpp ^
+	roach.cpp ^
+	rpg.cpp ^
+	satchel.cpp ^
+	schedule.cpp ^
+	scientist.cpp ^
+	scripted.cpp ^
+	shotgun.cpp ^
+	singleplay_gamerules.cpp ^
+	skill.cpp ^
+	sound.cpp ^
+	soundent.cpp ^
+	spectator.cpp ^
+	squadmonster.cpp ^
+	squeakgrenade.cpp ^
+	subs.cpp ^
+	talkmonster.cpp ^
+	teamplay_gamerules.cpp ^
+	tempmonster.cpp ^
+	tentacle.cpp ^
+	triggers.cpp ^
+	tripmine.cpp ^
+	turret.cpp ^
+	util.cpp ^
+	weapons.cpp ^
+	world.cpp ^
+	xen.cpp ^
+	zombie.cpp ^
 	../pm_shared/pm_debug.c ../pm_shared/pm_math.c ../pm_shared/pm_shared.c
 set DEFINES=/DCLIENT_WEAPONS /Dsnprintf=_snprintf /DNO_VOICEGAMEMGR
 set LIBS=user32.lib


### PR DESCRIPTION
It worked without spaces in older wine versions, probably due to a bug, but stopped working recently (since wine 4 or even earlier, idk)