### PR TITLE
Fix momentary_door sounds

### DIFF
--- a/dlls/doors.cpp
+++ b/dlls/doors.cpp
@@ -926,6 +926,7 @@ public:
 	void Spawn( void );
 	void Precache( void );
 	void EXPORT MomentaryMoveDone( void );
+	void EXPORT StopMoveSound( void );
 
 	void KeyValue( KeyValueData *pkvd );
 	void Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
@@ -1118,6 +1119,14 @@ void CMomentaryDoor::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYP
 
 void CMomentaryDoor::MomentaryMoveDone( void )
 {
+	SetThink(&CMomentaryDoor::StopMoveSound);
+	pev->nextthink = pev->ltime + 0.1;
+}
+
+void CMomentaryDoor::StopMoveSound()
+{
 	STOP_SOUND( ENT( pev ), CHAN_STATIC, STRING( pev->noiseMoving ) );
 	EMIT_SOUND( ENT( pev ), CHAN_STATIC, STRING( pev->noiseArrived ), 1, ATTN_NORM );
+	pev->nextthink = -1;
+	ResetThink();
 }


### PR DESCRIPTION
Fix #79 
Note that it has a new export function.So if you load a save made with this fix in the version without the fix it won't restore a Think function (if the save was made when the function is set). I don't think it's an issue though.

The fix is based on XashXT solution https://github.com/FWGS/XashXT/blob/master/server/doors.cpp#L1177
https://github.com/FWGS/XashXT/blob/master/server/doors.cpp#L1192