### PR TITLE
Fix crowbar delay after the first hit

### DIFF
--- a/dlls/crowbar.cpp
+++ b/dlls/crowbar.cpp
@@ -330,7 +330,11 @@ int CCrowbar::Swing( int fFirst )
 		SetThink( &CCrowbar::Smack );
 		pev->nextthink = UTIL_WeaponTimeBase() + 0.2;
 #endif
+#if CROWBAR_DELAY_FIX
 		m_flNextPrimaryAttack = UTIL_WeaponTimeBase() + 0.25;
+#else
+		m_flNextPrimaryAttack = GetNextAttackDelay( 0.25 );
+#endif
 	}
 #ifdef CROWBAR_IDLE_ANIM
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + UTIL_SharedRandomFloat( m_pPlayer->random_seed, 10, 15 );

--- a/dlls/crowbar.cpp
+++ b/dlls/crowbar.cpp
@@ -330,7 +330,7 @@ int CCrowbar::Swing( int fFirst )
 		SetThink( &CCrowbar::Smack );
 		pev->nextthink = UTIL_WeaponTimeBase() + 0.2;
 #endif
-		m_flNextPrimaryAttack = GetNextAttackDelay( 0.25 );
+		m_flNextPrimaryAttack = UTIL_WeaponTimeBase() + 0.25;
 	}
 #ifdef CROWBAR_IDLE_ANIM
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + UTIL_SharedRandomFloat( m_pPlayer->random_seed, 10, 15 );


### PR DESCRIPTION
Sometimes there's a noticable delay before the next animation after the first hit on breakable.

You don't need to merge it into master. Just leave it as PR or make another branch. It can be useful for modders.

@nekonomicon you can use it for your reimplementations of mods.