### PR TITLE
Build: Swapped Win32 check for MSVC check

### DIFF
--- a/dlls/wscript
+++ b/dlls/wscript
@@ -10,7 +10,7 @@ def options(opt):
 	return
 
 def configure(conf):
-	if conf.env.DEST_OS == 'win32':
+	if conf.env.COMPILER_CC == 'msvc':
 		# hl.def removes MSVC function name decoration from GiveFnptrsToDll on Windows.
 		# Without this, the lookup for this function fails.
 		hlDefNode = conf.path.find_resource("./hl.def")


### PR DESCRIPTION
@mittorn commented that technically I should have been checking against the compiler rather than the target OS, since `/def` is a MSVC-specific flag.