### PR TITLE
build: fix travis ci

### DIFF
--- a/dlls/wscript
+++ b/dlls/wscript
@@ -16,7 +16,7 @@ def configure(conf):
 		hlDefNode = conf.path.find_resource("./hl.def")
 
 		if hlDefNode is not None:
-			conf.env.append_unique('LINKFLAGS', '/def:{}'.format(hlDefNode.abspath()))
+			conf.env.append_unique('LINKFLAGS', '/def:%s' % hlDefNode.abspath())
 		else:
 			conf.fatal("Could not find hl.def")
 

--- a/dlls/wscript
+++ b/dlls/wscript
@@ -16,7 +16,7 @@ def configure(conf):
 		hlDefNode = conf.path.find_resource("./hl.def")
 
 		if hlDefNode is not None:
-			conf.env.append_unique('LINKFLAGS', f'/def:{hlDefNode.abspath()}')
+			conf.env.append_unique('LINKFLAGS', '/def:{}'.format(hlDefNode.abspath()))
 		else:
 			conf.fatal("Could not find hl.def")
 


### PR DESCRIPTION
I think travis is still using Python 3.4.*, so f-strings are not supported yet and android engine doesn't build.