### PR TITLE
Fix shockroach

### DIFF
--- a/dlls/gearbox/shockroach.cpp
+++ b/dlls/gearbox/shockroach.cpp
@@ -163,9 +163,7 @@ void CShockRoach::MonsterThink(void)
 	}
 	if (lifeTime >= gSkillData.sroachLifespan)
 	{
-		pev->health = -1;
-		Killed(pev, 0);
-		return;
+		TakeDamage(pev, pev, pev->health, DMG_NEVERGIB);
 	}
 
 	CHeadCrab::MonsterThink();


### PR DESCRIPTION
Let monster code handle shockroach death at right moment. The early return was a bad idea because prevented the change of monster state at some conditions.