### PR TITLE
client: wscript: add winmm.lib dependency (win32)

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -132,6 +132,9 @@ endif()
 
 if(WIN32)
 	target_link_libraries( ${CLDLL_LIBRARY} user32.lib )
+	if (GOLDSOURCE_SUPPORT)
+		target_link_libraries( ${CLDLL_LIBRARY} winmm.lib )
+	endif()
 endif()
 
 set_target_properties (${CLDLL_LIBRARY} PROPERTIES

--- a/cl_dll/wscript
+++ b/cl_dll/wscript
@@ -10,11 +10,14 @@ def options(opt):
 	return
 
 def configure(conf):
-	if conf.env.GOLDSRC and conf.env.DEST_OS != 'win32':
-		conf.check_cc(lib='dl')
-
 	if conf.env.DEST_OS == 'win32':
 		conf.check_cxx(lib='user32')
+
+	if conf.env.GOLDSRC:
+		if conf.env.DEST_OS == 'win32':
+			conf.check_cxx(lib='winmm')
+		else:
+			conf.check_cc(lib='dl')
 
 def build(bld):
 	source = bld.path.parent.ant_glob([
@@ -101,11 +104,14 @@ def build(bld):
 		defines += ['GOLDSOURCE_SUPPORT']
 
 	libs = []
-	if bld.env.GOLDSRC and bld.env.DEST_OS != 'win32':
-		libs += ['DL']
-
 	if bld.env.DEST_OS == 'win32':
 		libs += ["USER32"]
+
+	if bld.env.GOLDSRC:
+		if bld.env.DEST_OS == 'win32':
+			libs += ["WINMM"]
+		else:
+			libs += ['DL']
 
 	if bld.env.DEST_OS not in ['android', 'dos']:
 		install_path = os.path.join(bld.env.GAMEDIR, bld.env.CLIENT_DIR)


### PR DESCRIPTION
This fixes a linker error when compiling for win32 with Goldsrc Support enabled.

This is based on a linker failure I experienced on my end, I'm unsure if it's fine for anybody else.