### PR TITLE
server: fix monster yaw speed

### DIFF
--- a/dlls/basemonster.h
+++ b/dlls/basemonster.h
@@ -328,5 +328,9 @@ public:
 	BOOL CineCleanup();
 
 	CBaseEntity* DropItem( const char *pszItemName, const Vector &vecPos, const Vector &vecAng );// drop an item.
+
+#ifdef MONSTER_YAWSPEED_FIX
+	float m_flLastYawTime;
+#endif
 };
 #endif // BASEMONSTER_H

--- a/dlls/monsters.cpp
+++ b/dlls/monsters.cpp
@@ -2022,6 +2022,10 @@ void CBaseMonster::MonsterInit( void )
 	SetThink( &CBaseMonster::MonsterInitThink );
 	pev->nextthink = gpGlobals->time + 0.1f;
 	SetUse( &CBaseMonster::MonsterUse );
+
+#ifdef MONSTER_YAWSPEED_FIX
+	m_flLastYawTime = gpGlobals->time;
+#endif
 }
 
 //=========================================================
@@ -2504,7 +2508,15 @@ float CBaseMonster::ChangeYaw( int yawSpeed )
 	ideal = pev->ideal_yaw;
 	if( current != ideal )
 	{
+#ifdef MONSTER_YAWSPEED_FIX
+		float delta = gpGlobals->time - m_flLastYawTime;
+		if( delta > 0.25 )
+			delta = 0.25;
+
+		speed = (float)yawSpeed * delta * 2;
+#else
 		speed = (float)yawSpeed * gpGlobals->frametime * 10;
+#endif
 		move = ideal - current;
 
 		if( ideal > current )
@@ -2547,6 +2559,10 @@ float CBaseMonster::ChangeYaw( int yawSpeed )
 	}
 	else
 		move = 0;
+
+#ifdef MONSTER_YAWSPEED_FIX
+	m_flLastYawTime = gpGlobals->time;
+#endif
 
 	return move;
 }

--- a/wscript
+++ b/wscript
@@ -275,6 +275,7 @@ def configure(conf):
 	conf.define('CROWBAR_DELAY_FIX', False)
 	conf.define('CROWBAR_FIX_RAPID_CROWBAR', False)
 	conf.define('GAUSS_OVERCHARGE_FIX', False)
+	conf.define('MONSTER_YAWSPEED_FIX', False)
 
 	if conf.env.DEST_OS == 'android' or conf.options.ENABLE_MOD_HACKS:
 		conf.define('MOBILE_HACKS', '1')


### PR DESCRIPTION
This makes the yaw speed for all monsters (scientists, headcrabs, etc.) framerate independent.

Fix by [Solokiller](https://github.com/Solokiller) with [mikela-valve](https://github.com/mikela-valve)'s adjustments:
https://github.com/ValveSoftware/halflife/issues/2458

NOTE: **MONSTER_YAWSPEED_FIX** will need to be defined, feel free to remove the need for it if it should be enabled by default.