### PR TITLE
Fix checking for gag spawnflag

### DIFF
--- a/dlls/monsterstate.cpp
+++ b/dlls/monsterstate.cpp
@@ -66,7 +66,7 @@ void CBaseMonster::RunAI( void )
 
 	// IDLE sound permitted in ALERT state is because monsters were silent in ALERT state. Only play IDLE sound in IDLE state
 	// once we have sounds for that state.
-	if( ( m_MonsterState == MONSTERSTATE_IDLE || m_MonsterState == MONSTERSTATE_ALERT ) && RANDOM_LONG( 0, 99 ) == 0 && !( pev->flags & SF_MONSTER_GAG ) )
+	if( ( m_MonsterState == MONSTERSTATE_IDLE || m_MonsterState == MONSTERSTATE_ALERT ) && RANDOM_LONG( 0, 99 ) == 0 && !( pev->spawnflags & SF_MONSTER_GAG ) )
 	{
 		IdleSound();
 	}


### PR DESCRIPTION
Should check against `pev->spawnflags` rather than `pev->flags`