### PR TITLE
Fix crowbar smack think time

### DIFF
--- a/dlls/crowbar.cpp
+++ b/dlls/crowbar.cpp
@@ -335,7 +335,7 @@ int CCrowbar::Swing( int fFirst )
 		m_pPlayer->m_iWeaponVolume = (int)( flVol * CROWBAR_WALLHIT_VOLUME );
 
 		SetThink( &CCrowbar::Smack );
-		pev->nextthink = UTIL_WeaponTimeBase() + 0.2f;
+		pev->nextthink = gpGlobals->time + 0.2f;
 #endif
 #if CROWBAR_DELAY_FIX
 		m_flNextPrimaryAttack = UTIL_WeaponTimeBase() + 0.25f;


### PR DESCRIPTION
The time for think should be a global time not a UTIL_WeaponTimeBase.
Issue in Valve repo: https://github.com/ValveSoftware/halflife/issues/2296
Apparently it was actually updated in Steam version of Half-Life.