### PR TITLE
Match opfor garg size

### DIFF
--- a/dlls/gargantua.cpp
+++ b/dlls/gargantua.cpp
@@ -736,7 +736,7 @@ void CGargantua::Spawn()
 	Precache();
 
 	SET_MODEL( ENT( pev ), "models/garg.mdl" );
-	UTIL_SetSize( pev, Vector( -32, -32, 0 ), Vector( 32, 32, 64 ) );
+	UTIL_SetSize( pev, Vector( -40, -40, 0 ), Vector( 40, 40, 214 ) );
 
 	pev->solid		= SOLID_SLIDEBOX;
 	pev->movetype		= MOVETYPE_STEP;


### PR DESCRIPTION
Garg has a different size in opfor as seen in decompiled code:

```cpp
  LODWORD(v11.x) = 1109393408;
  LODWORD(v11.y) = 1109393408;
  LODWORD(v11.z) = 1129709568;
  LODWORD(v10.x) = -1038090240;
  LODWORD(v10.y) = -1038090240;
  LODWORD(v10.z) = 0;
  UTIL_SetSize(v1, &v10, &v11);
```

If you translate these ints to float you'll get the values in the commit.