### PR TITLE
Fix graphs directory being created with strange permissions

### DIFF
--- a/dlls/nodes.cpp
+++ b/dlls/nodes.cpp
@@ -48,7 +48,7 @@ LINK_ENTITY_TO_CLASS( info_node_air, CNodeEnt )
 #elif !_WIN32
 #include <unistd.h>
 #include <sys/stat.h>
-#define CreateDirectoryA(p, n) mkdir(p,777)
+#define CreateDirectoryA(p, n) mkdir(p, 0777)
 #endif
 
 //=========================================================


### PR DESCRIPTION
The regression was introduced in https://github.com/FWGS/hlsdk-xash3d/commit/9a08968453412b7279498d813f7c0b94444e7fae#diff-852370112d0ba140ddbadf08336840e25b015b2bcfe58417a996999eeaf00de1

@mittorn was there a problem with octal literals on OpenWatcom?