### PR TITLE
Fix possible bug with talkmonster facing during the script

### DIFF
--- a/dlls/talkmonster.cpp
+++ b/dlls/talkmonster.cpp
@@ -847,7 +847,8 @@ void CTalkMonster::Touch( CBaseEntity *pOther )
 		if( speed > 50.0f )
 		{
 			SetConditions( bits_COND_CLIENT_PUSH );
-			MakeIdealYaw( pOther->pev->origin );
+			if ( m_MonsterState != MONSTERSTATE_SCRIPT )
+				MakeIdealYaw( pOther->pev->origin );
 		}
 	}
 }


### PR DESCRIPTION
In Half-Life talkmonsters (barneys and scientists) react to player's touch. One of the consequences is the ideal yaw change. It can mess up with scripts since it happens in any monster state.

Example: load c0a0d, wait for transition to c0a0e (if you load c0a0e straight from the console, the barney will be missing). When barney walks to the button try to mess around him during the scripted `intropush` animation. The barney will face at you instead of the button while playing the animation.

I'm not actually sure why monster needs to turn to the player in the first place. It's probably left so if the monster failed to walk away from the player's path, it at least would face the player displaying the powerless gaze.
Probably it also shouldn't happen during the combat since monster is busy anyway. So the more correct way to fix it is to check if the interrupt mask of the current schedule includes the bits_COND_CLIENT_PUSH, but I did not want to complicate it.