### PR TITLE
Fixed incorrect field types in CBaseAnimating save data table.

### DIFF
--- a/dlls/animating.cpp
+++ b/dlls/animating.cpp
@@ -28,11 +28,11 @@
 
 TYPEDESCRIPTION	CBaseAnimating::m_SaveData[] =
 {
-	DEFINE_FIELD( CBaseMonster, m_flFrameRate, FIELD_FLOAT ),
-	DEFINE_FIELD( CBaseMonster, m_flGroundSpeed, FIELD_FLOAT ),
-	DEFINE_FIELD( CBaseMonster, m_flLastEventCheck, FIELD_TIME ),
-	DEFINE_FIELD( CBaseMonster, m_fSequenceFinished, FIELD_BOOLEAN ),
-	DEFINE_FIELD( CBaseMonster, m_fSequenceLoops, FIELD_BOOLEAN ),
+	DEFINE_FIELD( CBaseAnimating, m_flFrameRate, FIELD_FLOAT ),
+	DEFINE_FIELD( CBaseAnimating, m_flGroundSpeed, FIELD_FLOAT ),
+	DEFINE_FIELD( CBaseAnimating, m_flLastEventCheck, FIELD_TIME ),
+	DEFINE_FIELD( CBaseAnimating, m_fSequenceFinished, FIELD_BOOLEAN ),
+	DEFINE_FIELD( CBaseAnimating, m_fSequenceLoops, FIELD_BOOLEAN ),
 };
 
 IMPLEMENT_SAVERESTORE( CBaseAnimating, CBaseDelay )


### PR DESCRIPTION
See ValveSoftware/halflife#3189.