### PR TITLE
Fixed wrong base class specified in CMultisource save restore.

### DIFF
--- a/dlls/buttons.cpp
+++ b/dlls/buttons.cpp
@@ -130,7 +130,7 @@ TYPEDESCRIPTION CMultiSource::m_SaveData[] =
 	DEFINE_FIELD( CMultiSource, m_globalstate, FIELD_STRING ),
 };
 
-IMPLEMENT_SAVERESTORE( CMultiSource, CBaseEntity )
+IMPLEMENT_SAVERESTORE( CMultiSource, CPointEntity )
 
 LINK_ENTITY_TO_CLASS( multisource, CMultiSource )
 


### PR DESCRIPTION
See ValveSoftware/halflife#3193.