### PR TITLE
Fixed wrong base class specified in CBreakable save restore.

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -139,7 +139,7 @@ TYPEDESCRIPTION CBreakable::m_SaveData[] =
 	// Explosion magnitude is stored in pev->impulse
 };
 
-IMPLEMENT_SAVERESTORE( CBreakable, CBaseEntity )
+IMPLEMENT_SAVERESTORE( CBreakable, CBaseDelay )
 
 void CBreakable::Spawn( void )
 {


### PR DESCRIPTION
See ValveSoftware/halflife#3195.