### PR TITLE
Restore Hornetgun fire phase.

### DIFF
--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -1637,6 +1637,7 @@ IMPLEMENT_SAVERESTORE( CEgon, CBasePlayerWeapon )
 TYPEDESCRIPTION CHgun::m_SaveData[] =
 {
 	DEFINE_FIELD( CHgun, m_flRechargeTime, FIELD_TIME ),
+	DEFINE_FIELD( CHgun, m_iFirePhase, FIELD_INTEGER ),
 };
 
 IMPLEMENT_SAVERESTORE( CHgun, CBasePlayerWeapon )

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -870,7 +870,7 @@ public:
 
 	float m_flRechargeTime;
 
-	int m_iFirePhase;// don't save me.
+	int m_iFirePhase;
 
 	virtual BOOL UseDecrement( void )
 	{ 


### PR DESCRIPTION
`m_iFirePhase` should be saved so it can be correctly restored on game load.