### PR TITLE
Use filtered command buffer when string came from network

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -167,11 +167,16 @@ int DLLEXPORT Initialize( cl_enginefunc_t *pEnginefuncs, int iVersion )
 	if( iVersion != CLDLL_INTERFACE_VERSION )
 		return 0;
 
-	memcpy( &gEngfuncs, pEnginefuncs, sizeof(cl_enginefunc_t) );
+	// for now filterstuffcmd is last in the engine interface
+	memcpy( &gEngfuncs, pEnginefuncs, sizeof(cl_enginefunc_t) - sizeof( void * ) );
 
 	if( gEngfuncs.pfnGetCvarPointer( "cl_filterstuffcmd" ) != 0 )
 	{
 		gEngfuncs.pfnFilteredClientCmd = gEngfuncs.pfnClientCmd;
+	}
+	else
+	{
+		gEngfuncs.pfnFilteredClientCmd = pEnginefuncs->pfnFilteredClientCmd;
 	}
 
 	EV_HookEvents();

--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -169,6 +169,11 @@ int DLLEXPORT Initialize( cl_enginefunc_t *pEnginefuncs, int iVersion )
 
 	memcpy( &gEngfuncs, pEnginefuncs, sizeof(cl_enginefunc_t) );
 
+	if( gEngfuncs.pfnGetCvarPointer( "cl_filterstuffcmd" ) != 0 )
+	{
+		gEngfuncs.pfnFilteredClientCmd = gEngfuncs.pfnClientCmd;
+	}
+
 	EV_HookEvents();
 
 	return 1;

--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -170,7 +170,7 @@ int DLLEXPORT Initialize( cl_enginefunc_t *pEnginefuncs, int iVersion )
 	// for now filterstuffcmd is last in the engine interface
 	memcpy( &gEngfuncs, pEnginefuncs, sizeof(cl_enginefunc_t) - sizeof( void * ) );
 
-	if( gEngfuncs.pfnGetCvarPointer( "cl_filterstuffcmd" ) != 0 )
+	if( gEngfuncs.pfnGetCvarPointer( "cl_filterstuffcmd" ) == 0 )
 	{
 		gEngfuncs.pfnFilteredClientCmd = gEngfuncs.pfnClientCmd;
 	}

--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -577,7 +577,7 @@ void CHudSpectator::DirectorMessage( int iSize, void *pbuf )
 		case DRC_CMD_FADE:
 			break;
 		case DRC_CMD_STUFFTEXT:
-			ClientCmd( READ_STRING() );
+			gEngfuncs.pfnFilteredClientCmd( READ_STRING() );
 			break;
 		default:
 			gEngfuncs.Con_DPrintf( "CHudSpectator::DirectorMessage: unknown command %i.\n", cmd );

--- a/cl_dll/vgui_TeamFortressViewport.h
+++ b/cl_dll/vgui_TeamFortressViewport.h
@@ -667,7 +667,7 @@ public:
 
 	virtual void actionPerformed(Panel *panel)
 	{
-		gEngfuncs.pfnClientCmd( m_pszCommand );
+		gEngfuncs.pfnFilteredClientCmd( m_pszCommand );
 
 		if( m_iCloseVGUIMenu )
 			gViewPort->HideTopMenu();

--- a/engine/cdll_int.h
+++ b/engine/cdll_int.h
@@ -303,6 +303,9 @@ typedef struct cl_enginefuncs_s
 	int		(*pfnGetAppID)( void );
 	cmdalias_t	*(*pfnGetAliases)( void );
 	void		(*pfnVguiWrap2_GetMouseDelta)( int *x, int *y );
+
+	// added in 2019 update, not documented yet
+	int             (*pfnFilteredClientCmd)( const char *cmd );
 } cl_enginefunc_t;
 
 #define CLDLL_INTERFACE_VERSION	7


### PR DESCRIPTION
This is a client part of https://github.com/FWGS/xash3d-fwgs/pull/666

In theory, it must be compatible with the latest GoldSource, because the undocumented interface comes from it.

~~However, applying this patch will make client incompatible with older GoldSource and Xash3D builds, see how `Initialize( cl_enginefunc_t *, int )` is implemented.~~

Solved. We only use filtering if engine has cl_filterstuffcmd cvar.