### PR TITLE
Use valid animation extension for pipe.

### DIFF
--- a/dlls/visitors/pipe.cpp
+++ b/dlls/visitors/pipe.cpp
@@ -104,7 +104,7 @@ int CPipe::AddToPlayer( CBasePlayer *pPlayer )
 
 BOOL CPipe::Deploy()
 {
-	return DefaultDeploy("models/v_pipe.mdl", "models/p_pipe.mdl", PIPE_DRAW, "pipe");
+	return DefaultDeploy("models/v_pipe.mdl", "models/p_pipe.mdl", PIPE_DRAW, "crowbar");
 }
 
 void CPipe::Holster(int skiplocal /* = 0 */)


### PR DESCRIPTION
This issue also appears in the original mod.

The player model does not have animations suffixed pipe, so it defaults to the first sequence (idle).

The following changes make the pipe use 'crowbar' anim extension so it can pick a valid sequence.