### PR TITLE
Apply CROWBAR_FIX_RAPID_CROWBAR to knife

### DIFF
--- a/dlls/gearbox/knife.cpp
+++ b/dlls/gearbox/knife.cpp
@@ -228,7 +228,12 @@ int CKnife::Swing(int fFirst)
 				}
 				m_pPlayer->m_iWeaponVolume = KNIFE_BODYHIT_VOLUME;
 				if (!pEntity->IsAlive())
+				{
+#if CROWBAR_FIX_RAPID_CROWBAR
+					m_flNextPrimaryAttack = GetNextAttackDelay(0.25);
+#endif
 					return TRUE;
+				}
 				else
 					flVol = 0.1;
 


### PR DESCRIPTION
Greetings and thank you for your time and consideration!

I observed that OpFor's knife still exhibits the rabid melee bug, even when building the server with the `CROWBAR_FIX_RAPID_CROWBAR` flag. This correction applies only to the crowbar, but the same code can fix the knife.

I don't know whether you would want to incorporate this code into knife.cpp as it is, or change the variable name and then apply it here.

Thank you again!