### PR TITLE
Fix drawing non-latin characters from titles.txt

### DIFF
--- a/cl_dll/message.cpp
+++ b/cl_dll/message.cpp
@@ -294,7 +294,7 @@ void CHudMessage::MessageDrawScan( client_textmessage_t *pMessage, float time )
 
 		for( j = 0; j < m_parms.lineLength; j++ )
 		{
-			m_parms.text = pLineStart[j];
+			m_parms.text = (unsigned char)pLineStart[j];
 			int next = m_parms.x + gHUD.m_scrinfo.charWidths[m_parms.text];
 			MessageScanNextChar();
 


### PR DESCRIPTION
My bad. I changed from `unsiged char` to `char` in this commit https://github.com/FWGS/hlsdk-xash3d/commit/f2f83cd0359d0453ecdd4116f814c106560e9142