### PR TITLE
Build with GoldSource input by default on Windows and Linux

### DIFF
--- a/.github/workflows/.github.yml
+++ b/.github/workflows/.github.yml
@@ -49,21 +49,16 @@ jobs:
         ./steam-runtime/setup_chroot.sh --i386 --tarball ./com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
         sudo sed -i 's/groups=sudo/groups=adm/g' /etc/schroot/chroot.d/steamrt_scout_i386.conf
 
-    - name: Build with xash3d-fwgs input
+    - name: Build on Linux
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        schroot --chroot steamrt_scout_i386 -- cmake -B build-fwgs -S . -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-undefined"
-        schroot --chroot steamrt_scout_i386 -- cmake --build build-fwgs --target all
-    - name: Build with goldsource input
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        schroot --chroot steamrt_scout_i386 -- cmake -B build -S . -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-undefined" -DGOLDSOURCE_SUPPORT=ON -DCMAKE_INSTALL_PREFIX="$PWD/dist"
+        schroot --chroot steamrt_scout_i386 -- cmake -B build -S . -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-undefined" -DCMAKE_INSTALL_PREFIX="$PWD/dist"
         schroot --chroot steamrt_scout_i386 -- cmake --build build --target all
         schroot --chroot steamrt_scout_i386 -- cmake --build build --target install
-    - name: Build with goldsource input and vgui
+    - name: Build on Linux with vgui
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.cc, 'gcc')
       run: |
-        schroot --chroot steamrt_scout_i386 -- cmake -B build-vgui -S . -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-undefined" -DGOLDSOURCE_SUPPORT=ON -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="$PWD/dist-vgui"
+        schroot --chroot steamrt_scout_i386 -- cmake -B build-vgui -S . -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-undefined" -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="$PWD/dist-vgui"
         cp vgui_support/vgui-dev/lib/vgui.so build-vgui/cl_dll
         schroot --chroot steamrt_scout_i386 -- cmake --build build-vgui --target all
         schroot --chroot steamrt_scout_i386 -- cmake --build build-vgui --target install
@@ -78,15 +73,15 @@ jobs:
     - name: Add msbuild to PATH
       if: startsWith(matrix.os, 'windows')
       uses: microsoft/setup-msbuild@v1.0.2
-    - name: Build with msvc
+    - name: Build on Windows
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 16 2019" -A Win32 -B build -DGOLDSOURCE_SUPPORT=ON -DCMAKE_INSTALL_PREFIX="dist"
+        cmake -G "Visual Studio 16 2019" -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist"
         msbuild -verbosity:normal /property:Configuration=Release build/INSTALL.vcxproj
-    - name: Build with msvc and vgui
+    - name: Build on Windows with vgui
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 16 2019" -A Win32 -B build -DGOLDSOURCE_SUPPORT=ON -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="dist-vgui"
+        cmake -G "Visual Studio 16 2019" -A Win32 -B build -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="dist-vgui"
         msbuild -verbosity:normal /property:Configuration=Release build/INSTALL.vcxproj
 
     - name: Extract branch name

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ option(USE_NOVGUI_SCOREBOARD "Prefer non-VGUI Scoreboard when USE_VGUI is enable
 option(USE_VOICEMGR "Enable VOICE MANAGER." OFF)
 option(BUILD_CLIENT "Build client dll" ON)
 option(BUILD_SERVER "Build server dll" ON)
-option(GOLDSOURCE_SUPPORT "Build goldsource compatible client library" OFF)
 
 if (CMAKE_SIZEOF_VOID_P EQUAL 4 OR
 	((WIN32 OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
@@ -53,8 +52,10 @@ if (CMAKE_SIZEOF_VOID_P EQUAL 4 OR
 	OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"
 	OR CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64")))
 	option(64BIT "Disable auto -m32 appending to compiler flags" OFF)
+	option(GOLDSOURCE_SUPPORT "Build goldsource compatible client library" ON)
 else()
 	option(64BIT "Disable auto -m32 appending to compiler flags" ON)
+	option(GOLDSOURCE_SUPPORT "Build goldsource compatible client library" OFF)
 endif()
 
 option(BARNACLE_FIX_VISIBILITY "Enable barnacle tongue length fix" OFF)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ configuration:
 
 before_build:
   - git submodule update --init --recursive
-  - cmake -G "%GENERATOR_NAME%" -B build -DGOLDSOURCE_SUPPORT=ON -DCMAKE_INSTALL_PREFIX="dist"
+  - cmake -G "%GENERATOR_NAME%" -B build -DCMAKE_INSTALL_PREFIX="dist"
 
 artifacts:
   - path: dist


### PR DESCRIPTION
Note that I didn't touch building with waf. It still requires `--enable-goldsrc-support` option. I postponed it before we decide on what to do with waf as currently I see cmake is the main way to build the sdk. Maybe waf is gonna be used only for Android builds.

I also removed building with xash3d-fwgs input only from the github workflow as I don't see its value.

Next step will be to change the mention of GOLDSOURCE_SUPPORT option in build instructions (I'll do it in another PR with general README.md update).

@nekonomicon can you check if I did it right? The idea is that `GOLDSOURCE_SUPPORT` should set by default only when building x86 targets on Windows and Linux.